### PR TITLE
Fix Azure Blob Storage compatibility in cloud connectivity test

### DIFF
--- a/lib/utils_counting.sh
+++ b/lib/utils_counting.sh
@@ -421,10 +421,10 @@ _TEST_CLOUD_CONNECTIVITY() {
     fi
     
     # Test basic connectivity with configurable timeout
-    if ! timeout "${cloud_timeout}" rclone about "${RCLONE_REMOTE}:" ${RCLONE_FLAGS:-} &>/dev/null; then
+    if ! timeout "${cloud_timeout}" rclone lsd "${RCLONE_REMOTE}:" ${RCLONE_FLAGS:-} --max-depth 1 &>/dev/null; then
         warning "Cloud backup is enabled but connectivity test failed for remote '${RCLONE_REMOTE}'"
         warning "Check rclone configuration and network connectivity"
-        warning "Test manually with: rclone about ${RCLONE_REMOTE}:"
+        warning "Test manually with: rclone lsd ${RCLONE_REMOTE}:"
         COUNT_CLOUD_CONNECTION_ERROR="true"
         COUNT_CLOUD_CONNECTIVITY_STATUS="error"
         return 1


### PR DESCRIPTION
## Problem
The current cloud connectivity test uses `rclone about`, which is not supported by Azure Blob Storage (and has limited support in other providers). This causes backups to fail even when the Azure remote is correctly configured.

## Solution
Changed the connectivity test from `rclone about` to `rclone lsd --max-depth 1`, which:
  - Tests actual connectivity by listing directories/containers
  - Works across all rclone backends

## Changes
  - Line 424: Changed `rclone about` to `rclone lsd --max-depth 1`
  - Line 427: Updated warning message to reflect the new test command

## Testing
  Tested with:
  - ✅ Azure Blob Storage (account key authentication)
  - ✅ Azure Blob Storage (SAS token authentication)

## Benefits
  - Maintains backward compatibility with Google Drive and other providers while fixing Azure support
  - Improves cloud provider compatibility
  - Makes the script truly cloud-agnostic
  - More reliable connectivity testing