### PR TITLE
Localize install messages and add update check

### DIFF
--- a/cmd/proxsave/install_test.go
+++ b/cmd/proxsave/install_test.go
@@ -47,7 +47,7 @@ func TestPrintInstallFooterVariants(t *testing.T) {
 			permMessage := ""
 			if tt.err == nil {
 				permStatus = "ok"
-				permMessage = "permessi e proprietà normalizzati correttamente"
+				permMessage = "permissions and ownership normalized correctly"
 			}
 			output := captureStdout(t, func() {
 				printInstallFooter(tt.err, "/etc/proxmox-backup/backup.env", "/opt/proxsave", "CODE123", permStatus, permMessage)
@@ -65,7 +65,7 @@ func TestPrintInstallFooterVariants(t *testing.T) {
 				if !strings.Contains(output, "enter code: CODE123") {
 					t.Fatalf("expected telegram code mention")
 				}
-				if !strings.Contains(output, "permessi e proprietà normalizzati correttamente") {
+				if !strings.Contains(output, "permissions and ownership normalized correctly") {
 					t.Fatalf("expected permissions normalization confirmation line in footer, got %q", output)
 				}
 			}

--- a/cmd/proxsave/permissions.go
+++ b/cmd/proxsave/permissions.go
@@ -143,7 +143,7 @@ func fixPermissionsAfterInstall(ctx context.Context, configPath, baseDir string,
 	configPath = strings.TrimSpace(configPath)
 	baseDir = strings.TrimSpace(baseDir)
 	if configPath == "" {
-		return "skipped", "normalizzazione permessi non eseguita (percorso configurazione non disponibile)"
+		return "skipped", "permissions normalization skipped (configuration path unavailable)"
 	}
 
 	cfg, err := config.LoadConfig(configPath)
@@ -151,7 +151,7 @@ func fixPermissionsAfterInstall(ctx context.Context, configPath, baseDir string,
 		if bootstrap != nil {
 			bootstrap.Warning("Post-install: skipping permission fix, failed to load configuration: %v", err)
 		}
-		return "error", "impossibile normalizzare i permessi: caricamento configurazione fallito (vedi log)"
+		return "error", "unable to normalize permissions: failed to load configuration (see log)"
 	}
 
 	if strings.TrimSpace(cfg.BaseDir) == "" && baseDir != "" {
@@ -178,14 +178,14 @@ func fixPermissionsAfterInstall(ctx context.Context, configPath, baseDir string,
 	execPath := execInfo.ExecPath
 
 	status := "ok"
-	message := "permessi e proprietà normalizzati correttamente"
+	message := "permissions and ownership normalized correctly"
 
 	if _, secErr := security.Run(ctx, logger, cfg, configPath, execPath, nil); secErr != nil {
 		if bootstrap != nil {
 			bootstrap.Warning("Post-install: security permission checks reported errors (ignored): %v", secErr)
 		}
 		status = "error"
-		message = "errori durante i controlli di sicurezza per la normalizzazione permessi (non bloccante, vedi log)"
+		message = "errors during security permission checks (non-blocking, see log)"
 	}
 
 	if cfg.SetBackupPermissions {
@@ -198,10 +198,10 @@ func fixPermissionsAfterInstall(ctx context.Context, configPath, baseDir string,
 			}
 			if status != "error" {
 				status = "warning"
-				message = "permessi normalizzati con avvisi sui percorsi di backup (non bloccante, vedi log)"
+				message = "permissions normalized with warnings for backup paths (non-blocking, see log)"
 			}
 		} else if status == "ok" {
-			message = "permessi e proprietà normalizzati correttamente (inclusi i percorsi di backup)"
+			message = "permissions and ownership normalized correctly (including backup paths)"
 		}
 	}
 

--- a/internal/tui/wizard/install.go
+++ b/internal/tui/wizard/install.go
@@ -167,7 +167,7 @@ func RunInstallWizard(ctx context.Context, configPath string, baseDir string, bu
 	form.Form.AddFormItem(cloudDropdown)
 
 	cloudHint := tview.NewInputField().
-		SetLabel("  tip: remotename:path (via 'rclone config'), es. myremote:pbs-backups").
+		SetLabel("  Tip: remotename:path (via 'rclone config'), e.g. myremote:pbs-backups").
 		SetFieldWidth(0).
 		SetText("")
 	cloudHint.SetDisabled(true)


### PR DESCRIPTION
Replaces Italian messages with English in install, permissions, and wizard code. Adds a best-effort GitHub release check to notify users if a newer version of ProxSave is available, suggesting the use of --upgrade.