### PR TITLE
RFC: A small potential optimization in the installation script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -82,8 +82,7 @@ echo "--------------------------------------------"
 ###############################################
 LATEST_TAG="$(
   curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
-    | grep '"tag_name"' \
-    | head -n1 \
+    | { grep -m1 '"tag_name"' && cat >/dev/null; } \
     | cut -d '"' -f4
 )"
 


### PR DESCRIPTION
From the grep man page:

>    -m NUM      Stop reading a file after NUM matching lines.

Instead of having grep try to pattern match the whole input and then use `head -n1` to then discard everything but the first match, we could tell grep to stop after finding the first match and then discard the rest into the void (`/dev/null`). We need to continue to read from pipe and discard it since `curl` panics with error code `23` when the pipe is suddenly closed.

I run the installation script with this modification, and at least the happy path works as intended.

Alternatively, we could store the output from `curl` in a temporary variable and then use a here string on grep to extract the first match only: `grep -m1 '"tag_name"' <<< "$response" | cut -d '"' -f4`. This will also reduce the calls to external tools by one (`head`/`cat`).